### PR TITLE
 redirect / to /index.php in case default apache configuration only finds /index.html

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,7 @@ Options +FollowSymlinks
 RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^$ index.php
 RewriteRule ^(.*)$ index.php?q=$1 [L,QSA]
 
 # 若你的空间支持 SSL 请将下面各行最前面的注释符号删除 并将 t.orzdream.com 改为你的奶瓶腿地址


### PR DESCRIPTION
works on some PaaS services and servers didn't configure apache that much.
