### PR TITLE
bug fix in embedly image url

### DIFF
--- a/common/class.embedly.php
+++ b/common/class.embedly.php
@@ -30,7 +30,7 @@ function embedly_embed_thumbnails(&$feed) {
 					if (preg_match($embedly_re, $urls->expanded_url) > 0) { // If it matches an Embedly supported URL
 						$matched_urls[urlencode($urls->expanded_url)][] = $status->id;
 					} elseif (preg_match("/.*\.(jpg|png|gif)/i", $urls->expanded_url)) {
-						$feed[$status->id]->text .= '<br /><a href="{$urls->expanded_url}"><img src="'.img_proxy_url($urls->expanded_url, TRUE).'" style="max-width:150px;" /></a>';
+						$feed[$status->id]->text .= '<br /><a href="'.$urls->expanded_url.'"><img src="'.img_proxy_url($urls->expanded_url, TRUE).'" style="max-width:150px;" /></a>';
 					} else {
 						foreach ($services as $pattern => $thumbnail_url) {
 							if (preg_match_all($pattern, $urls->expanded_url, $matches, PREG_PATTERN_ORDER) > 0) {


### PR DESCRIPTION
修复缩略图的url变为 BASE_URL/%7B$urls-%3Eexpanded_url%7D 的问题
