### PR TITLE
用端口号来代替不稳定的HTTPS值来判断SSL

### DIFF
--- a/common/OAuth.php
+++ b/common/OAuth.php
@@ -239,7 +239,7 @@ class OAuthRequest {
    * attempt to build up a request from what was passed to the server
    */
   public static function from_request($http_method=NULL, $http_url=NULL, $parameters=NULL) {
-    $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != "on")
+    $scheme = (!isset($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] == '80')
               ? 'http'
               : 'https';
     @$http_url or $http_url = $scheme .

--- a/common/twitter.php
+++ b/common/twitter.php
@@ -1124,7 +1124,7 @@ function theme_user_header($user) {
 }
 
 function theme_get_avatar($object) {
-	if ($_SERVER['HTTPS'] == "on" && $object->profile_image_url_https) {
+	if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' && $object->profile_image_url_https) {
 		return $object->profile_image_url_https;
 	} else {
 		return $object->profile_image_url;

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 error_reporting(error_reporting() & ~E_NOTICE);
 
 if (!file_exists('config.php')) {
-	$base_url = isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] != "off" ? "https" : "http";
+	$base_url = isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' ? 'https' : 'http';
 	$base_url .= "://".$_SERVER["HTTP_HOST"];
 	$base_url .= ($directory = trim(dirname($_SERVER["SCRIPT_NAME"]), "/\,")) ? "/$directory/" : "/";
 

--- a/setup.php
+++ b/setup.php
@@ -1,7 +1,7 @@
 <?php
 error_reporting(E_ALL ^ E_WARNING);
 
-$base_url = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 'https' : 'http';
+$base_url = isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' ? 'https' : 'http';
 $base_url .= '://'.$_SERVER['HTTP_HOST'];
 
 if ($directory = trim(dirname($_SERVER['SCRIPT_NAME']), '/\,')){


### PR DESCRIPTION
这样即使在Nginx中不设置
fastcgi_param HTTPS on;
也可以正确得到BASE_URL
